### PR TITLE
Rename typings to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Baseline for creating js libs",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "scripts": {
     "build": "rimraf dist && microbundle",


### PR DESCRIPTION
`typings` is a synonym, but most references I find use `types` as the primary value

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package