### PR TITLE
Add missing module definition in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Baseline for creating js libs",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
This fixes so that the library will correctly expose the ES2015 module build to consumers.

For a description of the `module` definition: https://github.com/stereobooster/package.json#module

Docs from microbundle: https://github.com/developit/microbundle#specifying-builds-in-packagejson

I've not added the `umd:main` definition as it seems to be microbundle-specific and I can't see any use of it.